### PR TITLE
Build fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,8 +85,9 @@ file(MAKE_DIRECTORY ${SHADER_OUTPUT_DIR})
 foreach(SHADER ${SHADERS})
     get_filename_component(filename ${SHADER} NAME)
     add_custom_command(
-        OUTPUT ${SHADER}
-	    COMMAND ${GLSLANGVALIDATOR} -V ${SHADER} -o ${SHADER_OUTPUT_DIR}${filename}.spv
+        TARGET ${PROJECT_NAME}
+        POST_BUILD
+        COMMAND ${GLSLANGVALIDATOR} -V ${SHADER} -o ${SHADER_OUTPUT_DIR}${filename}.spv
         COMMENT "Rebuilding ${SHADER}.spv"
     )
 endforeach(SHADER)

--- a/src/vulkan/vulkanhelper.h
+++ b/src/vulkan/vulkanhelper.h
@@ -2,7 +2,7 @@
 
 #include <vulkan/vulkan.h>
 #include <iostream>
-#include <string>
+#include <string.h>
 #include <assert.h>
 
 std::string errorString(VkResult errorCode);


### PR DESCRIPTION
Two fixes:
- extension to header string (has to be either string.h or cstring)
- fix automatic shader builds